### PR TITLE
Fixes #17

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -45,7 +45,9 @@ header h1 {
   font-size: 2.5rem;
   font-weight: 800;
   background: linear-gradient(to right, #60a5fa, #3b82f6);
+  background-clip: text;
   -webkit-background-clip: text;
+  color: transparent;
   -webkit-text-fill-color: transparent;
   margin-bottom: 0.5rem;
 }
@@ -446,9 +448,17 @@ textarea:focus {
   font-size: 0.9rem;
 }
 
-.history-score-badge.score-high { color: var(--success); }
-.history-score-badge.score-mid  { color: var(--warning); }
-.history-score-badge.score-low  { color: var(--danger); }
+.history-score-badge.score-high {
+  color: var(--success);
+}
+
+.history-score-badge.score-mid {
+  color: var(--warning);
+}
+
+.history-score-badge.score-low {
+  color: var(--danger);
+}
 
 .history-date {
   color: var(--text-muted);

--- a/frontend/src/components/CodeInput.jsx
+++ b/frontend/src/components/CodeInput.jsx
@@ -11,36 +11,18 @@ import { useState } from 'react';
  * @param {function} onSubmit - Submit handler
  * @param {boolean} isLoading - Loading state for the submit button
  */
-const SUPPORTED_LANGUAGES = ['python', 'javascript', 'typescript', 'java', 'cpp', 'go'];
+const SUPPORTED_LANGUAGES = ['C', 'C++', 'Go', 'Java', 'JavaScript', 'Python', 'TypeScript'];
 
-const LANGUAGE_SAMPLES = {
-  python: `def find_max(numbers):
-    max_val = 0
-    for n in numbers:
-        if n > max_val:
-            max_val == n
-    return max_val
-
-print(find_max([-1, -2, -3]))`,
-  javascript: `function calculateSum(arr) {
-  let sum = 0;
-  for (let i = 0; i <= arr.length; i++) {
-    sum += arr[i];
-  }
-  return sum;
-}
-console.log(calculateSum([1, 2, 3]));`,
-  typescript: `function greet(person: string) {
-  return "Hello, " + persons;
-}
-console.log(greet("User"));`,
-  java: `public class Main {
-    public static void main(String[] args) {
-        int[] nums = {1, 2, 3};
-        System.out.println(nums[5]);
+export const LANGUAGE_SAMPLES = {
+  'C': `#include <stdio.h>
+int main() {
+    int x = 10;
+    if (x = 5) {
+        printf("Equal");
     }
+    return 0;
 }`,
-  cpp: `#include <iostream>
+  'C++': `#include <iostream>
 int main() {
     int x = 10;
     if (x = 5) {
@@ -48,12 +30,38 @@ int main() {
     }
     return 0;
 }`,
-  go: `package main
+  'Go': `package main
 import "fmt"
 func main() {
     x := 10
     fmt.Println("Value is", y)
-}`
+}`,
+  'Java': `public class Main {
+    public static void main(String[] args) {
+        int[] nums = {1, 2, 3};
+        System.out.println(nums[5]);
+    }
+}`,
+  'JavaScript': `function calculateSum(arr) {
+  let sum = 0;
+  for (let i = 0; i <= arr.length; i++) {
+    sum += arr[i];
+  }
+  return sum;
+}
+console.log(calculateSum([1, 2, 3]));`,
+  'Python': `def find_max(numbers):
+    max_val = 0
+    for n in numbers:
+        if n > max_val:
+            max_val == n
+    return max_val
+
+print(find_max([-1, -2, -3]))`,
+  'TypeScript': `function greet(person: string) {
+  return "Hello, " + persons;
+}
+console.log(greet("User"));`
 };
 
 const CodeInput = ({ code, setCode, language, setLanguage, onSubmit, isLoading }) => {
@@ -135,7 +143,7 @@ const CodeInput = ({ code, setCode, language, setLanguage, onSubmit, isLoading }
           >
             {SUPPORTED_LANGUAGES.map((lang) => (
               <option key={lang} value={lang}>
-                {lang.charAt(0).toUpperCase() + lang.slice(1)}
+                {lang}
               </option>
             ))}
           </select>
@@ -157,10 +165,18 @@ const CodeInput = ({ code, setCode, language, setLanguage, onSubmit, isLoading }
             type="button"
             className="btn btn-sample"
             onClick={() => {
-              const currentIndex = SUPPORTED_LANGUAGES.indexOf(language);
-              const nextIndex = (currentIndex + 1) % SUPPORTED_LANGUAGES.length;
-              const nextLang = SUPPORTED_LANGUAGES[nextIndex];
-              
+              const cycleLanguages = ['C', 'C++', 'Java', 'JavaScript', 'Python'];
+              let nextLang = language;
+
+              // If textarea is empty, load the current language's sample (default to C if not in cycle)
+              if (code === '') {
+                if (!cycleLanguages.includes(language)) nextLang = 'C';
+              } else {
+                const currentIndex = cycleLanguages.indexOf(language);
+                const nextIndex = (currentIndex + 1) % cycleLanguages.length;
+                nextLang = cycleLanguages[nextIndex];
+              }
+
               setLanguage(nextLang);
               setCode(LANGUAGE_SAMPLES[nextLang]);
             }}

--- a/frontend/src/components/CodeInput.jsx
+++ b/frontend/src/components/CodeInput.jsx
@@ -10,38 +10,50 @@ import React from 'react';
  * @param {function} onSubmit - Submit handler
  * @param {boolean} isLoading - Loading state for the submit button
  */
-const SUPPORTED_LANGUAGES = ['python', 'javascript', 'typescript', 'java', 'cpp', 'go', 'plaintext'];
+const SUPPORTED_LANGUAGES = ['python', 'javascript', 'typescript', 'java', 'cpp', 'go'];
 
-const SAMPLE_CODE = `# Python — contains intentional bugs for review demo
-def calculate_average(numbers):
-    total = 0
-    for i in range(len(numbers)):
-        total =+ numbers[i]   # bug: =+ should be +=
-    average = total / len(numbers)  # bug: ZeroDivisionError if list is empty
-    return average
+const LANGUAGE_SAMPLES = {
+  python: `def find_max(numbers):
+    max_val = 0
+    for n in numbers:
+        if n > max_val:
+            max_val == n
+    return max_val
 
-def find_duplicates(lst):
-    seen = []
-    duplicates = []
-    for item in lst:
-        if item in seen:
-            duplicates.append(item)
-        seen.append(item)  # bug: should append only if not already seen
-    return list(set(duplicates))
-
-def fetch_user(user_id):
-    users = {1: 'Alice', 2: 'Bob', 3: 'Charlie'}
-    return users[user_id]   # bug: KeyError if user_id not in dict; no default
-
-result = calculate_average([])
-print('Average:', result)
-
-dupes = find_duplicates([1, 2, 2, 3, 3, 3, 4])
-print('Duplicates:', dupes)
-
-user = fetch_user(99)
-print('User:', user)
-`;
+print(find_max([-1, -2, -3]))`,
+  javascript: `function calculateSum(arr) {
+  let sum = 0;
+  for (let i = 0; i <= arr.length; i++) {
+    sum += arr[i];
+  }
+  return sum;
+}
+console.log(calculateSum([1, 2, 3]));`,
+  typescript: `function greet(person: string) {
+  return "Hello, " + persons;
+}
+console.log(greet("User"));`,
+  java: `public class Main {
+    public static void main(String[] args) {
+        int[] nums = {1, 2, 3};
+        System.out.println(nums[5]);
+    }
+}`,
+  cpp: `#include <iostream>
+int main() {
+    int x = 10;
+    if (x = 5) {
+        std::cout << "Equal";
+    }
+    return 0;
+}`,
+  go: `package main
+import "fmt"
+func main() {
+    x := 10
+    fmt.Println("Value is", y)
+}`
+};
 
 const CodeInput = ({ code, setCode, language, setLanguage, onSubmit, isLoading }) => {
   return (
@@ -117,8 +129,12 @@ const CodeInput = ({ code, setCode, language, setLanguage, onSubmit, isLoading }
             type="button"
             className="btn btn-sample"
             onClick={() => {
-              setCode(SAMPLE_CODE);
-              setLanguage('python');
+              const currentIndex = SUPPORTED_LANGUAGES.indexOf(language);
+              const nextIndex = (currentIndex + 1) % SUPPORTED_LANGUAGES.length;
+              const nextLang = SUPPORTED_LANGUAGES[nextIndex];
+              
+              setLanguage(nextLang);
+              setCode(LANGUAGE_SAMPLES[nextLang]);
             }}
             disabled={isLoading}
             title="Load a buggy sample for testing"

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -9,7 +9,7 @@ import ReviewResult from '../components/ReviewResult';
  */
 function MainPage() {
   const [sourceCode, setSourceCode] = useState('');
-  const [language, setLanguage] = useState('python');
+  const [language, setLanguage] = useState('C');
   const [reviewData, setReviewData] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');


### PR DESCRIPTION
Language Dropdown
- Added C as a supported language with a buggy sample snippet
- Updated the supported languages list to: C, C++, Go, Java, JavaScript, Python, TypeScript
- Languages are now sorted in alphabetical order

Sample Code Button
- Button now cycles through:  C → C++ → Java → JavaScript → Python
- Go and TypeScript are excluded from the cycle

Default State
- Page now opens with C selected as the default language
- Textarea starts empty— sample code only loads when the button is clicked